### PR TITLE
Add prototype device schema and interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+###############################
+# Core EditorConfig Options   #
+###############################
+# All files
+[*]
+indent_style = space
+
+# XML project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,projitems,shproj,bonsai}]
+indent_size = 2
+
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+# Code files
+[*.{cs,csx}]
+indent_size = 4
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs}]
+# Organize usings
+dotnet_sort_system_directives_first = true

--- a/Generators/Generators.csproj
+++ b/Generators/Generators.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RootNamespace>Harp.TimestampGeneratorGen3</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <OutputPath>bin</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DeviceMetadata>..\device.yml</DeviceMetadata>
+    <IOMetadata>..\ios.yml</IOMetadata>
+  </PropertyGroup>
+  <PropertyGroup>
+    <InterfacePath>..\Interface\Harp.TimestampGeneratorGen3</InterfacePath>
+    <FirmwarePath>..\Firmware\Harp.TimestampGeneratorGen3</FirmwarePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Harp.Generators" Version="0.1.0-build032704" GeneratePathProperty="true" />
+  </ItemGroup>
+  <Target Name="TextTransform" BeforeTargets="AfterBuild">
+    <PropertyGroup>
+      <InterfaceFlags>-p:MetadataPath=$(DeviceMetadata) -p:Namespace=$(RootNamespace) -P=$(TargetDir)</InterfaceFlags>
+      <FirmwareFlags>-p:RegisterMetadataPath=$(DeviceMetadata) -p:IOMetadataPath=$(IOMetadata) -P=$(TargetDir)</FirmwareFlags>
+    </PropertyGroup>
+    <Exec WorkingDirectory="$(ProjectDir)"
+          Condition="Exists($(DeviceMetadata)) And $([System.String]::new('%(Content.Link)').EndsWith('Device.tt'))"
+          Command="t4 %(Content.Identity) $(InterfaceFlags) -o=$(InterfacePath)\%(Content.Link)" />
+    <Exec WorkingDirectory="$(ProjectDir)"
+          Condition="Exists($(IOMetadata)) And '%(Content.Link)' == 'Firmware.tt'"
+          Command="t4 %(Content.Identity) $(FirmwareFlags) -o=$(FirmwarePath)\app_ios_and_regs.h" />
+  </Target>
+</Project>

--- a/Interface/Harp.TimestampGeneratorGen3.sln
+++ b/Interface/Harp.TimestampGeneratorGen3.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32825.248
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{989C1B02-FB45-4FE0-9E25-80FCEB515EDD}") = "Harp.TimestampGeneratorGen3", "Harp.TimestampGeneratorGen3\Harp.TimestampGeneratorGen3.csproj", "{D33D8016-8B4D-4FE4-A389-EED134194B9A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D33D8016-8B4D-4FE4-A389-EED134194B9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D33D8016-8B4D-4FE4-A389-EED134194B9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D33D8016-8B4D-4FE4-A389-EED134194B9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D33D8016-8B4D-4FE4-A389-EED134194B9A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3D488FE3-E325-47E6-85C4-93686343DF69}
+	EndGlobalSection
+EndGlobal

--- a/Interface/Harp.TimestampGeneratorGen3/AsyncDevice.Generated.cs
+++ b/Interface/Harp.TimestampGeneratorGen3/AsyncDevice.Generated.cs
@@ -1,0 +1,358 @@
+using Bonsai.Harp;
+using System.Threading.Tasks;
+
+namespace Harp.TimestampGeneratorGen3
+{
+    /// <inheritdoc/>
+    public partial class Device
+    {
+        /// <summary>
+        /// Initializes a new instance of the asynchronous API to configure and interface
+        /// with TimestampGeneratorGen3 devices on the specified serial port.
+        /// </summary>
+        /// <param name="portName">
+        /// The name of the serial port used to communicate with the Harp device.
+        /// </param>
+        /// <returns>
+        /// A task that represents the asynchronous initialization operation. The value of
+        /// the <see cref="Task{TResult}.Result"/> parameter contains a new instance of
+        /// the <see cref="AsyncDevice"/> class.
+        /// </returns>
+        public static async Task<AsyncDevice> CreateAsync(string portName)
+        {
+            var device = new AsyncDevice(portName);
+            var whoAmI = await device.ReadWhoAmIAsync();
+            if (whoAmI != Device.WhoAmI)
+            {
+                var errorMessage = string.Format(
+                    "The device ID {1} on {0} was unexpected. Check whether a TimestampGeneratorGen3 device is connected to the specified serial port.",
+                    portName, whoAmI);
+                throw new HarpException(errorMessage);
+            }
+
+            return device;
+        }
+    }
+
+    /// <summary>
+    /// Represents an asynchronous API to configure and interface with TimestampGeneratorGen3 devices.
+    /// </summary>
+    public partial class AsyncDevice : Bonsai.Harp.AsyncDevice
+    {
+        internal AsyncDevice(string portName)
+            : base(portName)
+        {
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Config register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadConfigAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Config.Address));
+            return Config.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Config register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedConfigAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(Config.Address));
+            return Config.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the Config register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteConfigAsync(byte value)
+        {
+            var request = Config.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the DevicesConnected register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadDevicesConnectedAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(DevicesConnected.Address));
+            return DevicesConnected.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the DevicesConnected register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedDevicesConnectedAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(DevicesConnected.Address));
+            return DevicesConnected.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the RepeaterStatus register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadRepeaterStatusAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(RepeaterStatus.Address));
+            return RepeaterStatus.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the RepeaterStatus register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedRepeaterStatusAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(RepeaterStatus.Address));
+            return RepeaterStatus.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the RepeaterStatus register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteRepeaterStatusAsync(byte value)
+        {
+            var request = RepeaterStatus.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the BatteryRate register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<byte> ReadBatteryRateAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(BatteryRate.Address));
+            return BatteryRate.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the BatteryRate register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<byte>> ReadTimestampedBatteryRateAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadByte(BatteryRate.Address));
+            return BatteryRate.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the BatteryRate register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteBatteryRateAsync(byte value)
+        {
+            var request = BatteryRate.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the Battery register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<float> ReadBatteryAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadSingle(Battery.Address));
+            return Battery.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the Battery register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<float>> ReadTimestampedBatteryAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadSingle(Battery.Address));
+            return Battery.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the BatteryThresholdLow register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<float> ReadBatteryThresholdLowAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadSingle(BatteryThresholdLow.Address));
+            return BatteryThresholdLow.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the BatteryThresholdLow register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<float>> ReadTimestampedBatteryThresholdLowAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadSingle(BatteryThresholdLow.Address));
+            return BatteryThresholdLow.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the BatteryThresholdLow register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteBatteryThresholdLowAsync(float value)
+        {
+            var request = BatteryThresholdLow.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the BatteryThresholdHigh register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<float> ReadBatteryThresholdHighAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadSingle(BatteryThresholdHigh.Address));
+            return BatteryThresholdHigh.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the BatteryThresholdHigh register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<float>> ReadTimestampedBatteryThresholdHighAsync()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadSingle(BatteryThresholdHigh.Address));
+            return BatteryThresholdHigh.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the BatteryThresholdHigh register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteBatteryThresholdHighAsync(float value)
+        {
+            var request = BatteryThresholdHigh.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the BatteryCalibration0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadBatteryCalibration0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(BatteryCalibration0.Address));
+            return BatteryCalibration0.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the BatteryCalibration0 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedBatteryCalibration0Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(BatteryCalibration0.Address));
+            return BatteryCalibration0.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the BatteryCalibration0 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteBatteryCalibration0Async(ushort value)
+        {
+            var request = BatteryCalibration0.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the contents of the BatteryCalibration1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the register payload.
+        /// </returns>
+        public async Task<ushort> ReadBatteryCalibration1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(BatteryCalibration1.Address));
+            return BatteryCalibration1.GetPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the timestamped contents of the BatteryCalibration1 register.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
+        /// property contains the timestamped register payload.
+        /// </returns>
+        public async Task<Timestamped<ushort>> ReadTimestampedBatteryCalibration1Async()
+        {
+            var reply = await CommandAsync(HarpCommand.ReadUInt16(BatteryCalibration1.Address));
+            return BatteryCalibration1.GetTimestampedPayload(reply);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a value to the BatteryCalibration1 register.
+        /// </summary>
+        /// <param name="value">The value to be stored in the register.</param>
+        /// <returns>The task object representing the asynchronous write operation.</returns>
+        public async Task WriteBatteryCalibration1Async(ushort value)
+        {
+            var request = BatteryCalibration1.FromPayload(MessageType.Write, value);
+            await CommandAsync(request);
+        }
+    }
+}

--- a/Interface/Harp.TimestampGeneratorGen3/AsyncDevice.Generated.cs
+++ b/Interface/Harp.TimestampGeneratorGen3/AsyncDevice.Generated.cs
@@ -51,7 +51,7 @@ namespace Harp.TimestampGeneratorGen3
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the register payload.
         /// </returns>
-        public async Task<byte> ReadConfigAsync()
+        public async Task<ConfigurationFlags> ReadConfigAsync()
         {
             var reply = await CommandAsync(HarpCommand.ReadByte(Config.Address));
             return Config.GetPayload(reply);
@@ -64,7 +64,7 @@ namespace Harp.TimestampGeneratorGen3
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the timestamped register payload.
         /// </returns>
-        public async Task<Timestamped<byte>> ReadTimestampedConfigAsync()
+        public async Task<Timestamped<ConfigurationFlags>> ReadTimestampedConfigAsync()
         {
             var reply = await CommandAsync(HarpCommand.ReadByte(Config.Address));
             return Config.GetTimestampedPayload(reply);
@@ -75,7 +75,7 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="value">The value to be stored in the register.</param>
         /// <returns>The task object representing the asynchronous write operation.</returns>
-        public async Task WriteConfigAsync(byte value)
+        public async Task WriteConfigAsync(ConfigurationFlags value)
         {
             var request = Config.FromPayload(MessageType.Write, value);
             await CommandAsync(request);
@@ -114,7 +114,7 @@ namespace Harp.TimestampGeneratorGen3
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the register payload.
         /// </returns>
-        public async Task<byte> ReadRepeaterStatusAsync()
+        public async Task<RepeaterFlags> ReadRepeaterStatusAsync()
         {
             var reply = await CommandAsync(HarpCommand.ReadByte(RepeaterStatus.Address));
             return RepeaterStatus.GetPayload(reply);
@@ -127,7 +127,7 @@ namespace Harp.TimestampGeneratorGen3
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the timestamped register payload.
         /// </returns>
-        public async Task<Timestamped<byte>> ReadTimestampedRepeaterStatusAsync()
+        public async Task<Timestamped<RepeaterFlags>> ReadTimestampedRepeaterStatusAsync()
         {
             var reply = await CommandAsync(HarpCommand.ReadByte(RepeaterStatus.Address));
             return RepeaterStatus.GetTimestampedPayload(reply);
@@ -138,7 +138,7 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="value">The value to be stored in the register.</param>
         /// <returns>The task object representing the asynchronous write operation.</returns>
-        public async Task WriteRepeaterStatusAsync(byte value)
+        public async Task WriteRepeaterStatusAsync(RepeaterFlags value)
         {
             var request = RepeaterStatus.FromPayload(MessageType.Write, value);
             await CommandAsync(request);
@@ -151,7 +151,7 @@ namespace Harp.TimestampGeneratorGen3
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the register payload.
         /// </returns>
-        public async Task<byte> ReadBatteryRateAsync()
+        public async Task<BatteryRateConfiguration> ReadBatteryRateAsync()
         {
             var reply = await CommandAsync(HarpCommand.ReadByte(BatteryRate.Address));
             return BatteryRate.GetPayload(reply);
@@ -164,7 +164,7 @@ namespace Harp.TimestampGeneratorGen3
         /// A task that represents the asynchronous read operation. The <see cref="Task{TResult}.Result"/>
         /// property contains the timestamped register payload.
         /// </returns>
-        public async Task<Timestamped<byte>> ReadTimestampedBatteryRateAsync()
+        public async Task<Timestamped<BatteryRateConfiguration>> ReadTimestampedBatteryRateAsync()
         {
             var reply = await CommandAsync(HarpCommand.ReadByte(BatteryRate.Address));
             return BatteryRate.GetTimestampedPayload(reply);
@@ -175,7 +175,7 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="value">The value to be stored in the register.</param>
         /// <returns>The task object representing the asynchronous write operation.</returns>
-        public async Task WriteBatteryRateAsync(byte value)
+        public async Task WriteBatteryRateAsync(BatteryRateConfiguration value)
         {
             var request = BatteryRate.FromPayload(MessageType.Write, value);
             await CommandAsync(request);

--- a/Interface/Harp.TimestampGeneratorGen3/Device.Generated.cs
+++ b/Interface/Harp.TimestampGeneratorGen3/Device.Generated.cs
@@ -1,0 +1,1524 @@
+using Bonsai;
+using Bonsai.Harp;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+
+namespace Harp.TimestampGeneratorGen3
+{
+    /// <summary>
+    /// Generates events and processes commands for the TimestampGeneratorGen3 device connected
+    /// at the specified serial port.
+    /// </summary>
+    [Combinator(MethodName = nameof(Generate))]
+    [WorkflowElementCategory(ElementCategory.Source)]
+    [Description("Generates events and processes commands for the TimestampGeneratorGen3 device.")]
+    public partial class Device : Bonsai.Harp.Device, INamedElement
+    {
+        /// <summary>
+        /// Represents the unique identity class of the <see cref="TimestampGeneratorGen3"/> device.
+        /// This field is constant.
+        /// </summary>
+        public const int WhoAmI = 1158;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Device"/> class.
+        /// </summary>
+        public Device() : base(WhoAmI) { }
+
+        string INamedElement.Name => nameof(TimestampGeneratorGen3);
+
+        /// <summary>
+        /// Gets a read-only mapping from address to register type.
+        /// </summary>
+        public static new IReadOnlyDictionary<int, Type> RegisterMap { get; } = new Dictionary<int, Type>
+            (Bonsai.Harp.Device.RegisterMap.ToDictionary(entry => entry.Key, entry => entry.Value))
+        {
+            { 32, typeof(Config) },
+            { 33, typeof(DevicesConnected) },
+            { 34, typeof(RepeaterStatus) },
+            { 35, typeof(BatteryRate) },
+            { 36, typeof(Battery) },
+            { 37, typeof(BatteryThresholdLow) },
+            { 38, typeof(BatteryThresholdHigh) },
+            { 39, typeof(BatteryCalibration0) },
+            { 40, typeof(BatteryCalibration1) }
+        };
+    }
+
+    /// <summary>
+    /// Represents an operator that groups the sequence of <see cref="TimestampGeneratorGen3"/>" messages by register type.
+    /// </summary>
+    [Description("Groups the sequence of TimestampGeneratorGen3 messages by register type.")]
+    public partial class GroupByRegister : Combinator<HarpMessage, IGroupedObservable<Type, HarpMessage>>
+    {
+        /// <summary>
+        /// Groups an observable sequence of <see cref="TimestampGeneratorGen3"/> messages
+        /// by register type.
+        /// </summary>
+        /// <param name="source">The sequence of Harp device messages.</param>
+        /// <returns>
+        /// A sequence of observable groups, each of which corresponds to a unique
+        /// <see cref="TimestampGeneratorGen3"/> register.
+        /// </returns>
+        public override IObservable<IGroupedObservable<Type, HarpMessage>> Process(IObservable<HarpMessage> source)
+        {
+            return source.GroupBy(message => Device.RegisterMap[message.Address]);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that filters register-specific messages
+    /// reported by the <see cref="TimestampGeneratorGen3"/> device.
+    /// </summary>
+    /// <seealso cref="Config"/>
+    /// <seealso cref="DevicesConnected"/>
+    /// <seealso cref="RepeaterStatus"/>
+    /// <seealso cref="BatteryRate"/>
+    /// <seealso cref="Battery"/>
+    /// <seealso cref="BatteryThresholdLow"/>
+    /// <seealso cref="BatteryThresholdHigh"/>
+    /// <seealso cref="BatteryCalibration0"/>
+    /// <seealso cref="BatteryCalibration1"/>
+    [XmlInclude(typeof(Config))]
+    [XmlInclude(typeof(DevicesConnected))]
+    [XmlInclude(typeof(RepeaterStatus))]
+    [XmlInclude(typeof(BatteryRate))]
+    [XmlInclude(typeof(Battery))]
+    [XmlInclude(typeof(BatteryThresholdLow))]
+    [XmlInclude(typeof(BatteryThresholdHigh))]
+    [XmlInclude(typeof(BatteryCalibration0))]
+    [XmlInclude(typeof(BatteryCalibration1))]
+    [Description("Filters register-specific messages reported by the TimestampGeneratorGen3 device.")]
+    public class FilterMessage : FilterMessageBuilder, INamedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FilterMessage"/> class.
+        /// </summary>
+        public FilterMessage()
+        {
+            Register = new Config();
+        }
+
+        string INamedElement.Name
+        {
+            get => $"{nameof(TimestampGeneratorGen3)}.{GetElementDisplayName(Register)}";
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator which filters and selects specific messages
+    /// reported by the TimestampGeneratorGen3 device.
+    /// </summary>
+    /// <seealso cref="Config"/>
+    /// <seealso cref="DevicesConnected"/>
+    /// <seealso cref="RepeaterStatus"/>
+    /// <seealso cref="BatteryRate"/>
+    /// <seealso cref="Battery"/>
+    /// <seealso cref="BatteryThresholdLow"/>
+    /// <seealso cref="BatteryThresholdHigh"/>
+    /// <seealso cref="BatteryCalibration0"/>
+    /// <seealso cref="BatteryCalibration1"/>
+    [XmlInclude(typeof(Config))]
+    [XmlInclude(typeof(DevicesConnected))]
+    [XmlInclude(typeof(RepeaterStatus))]
+    [XmlInclude(typeof(BatteryRate))]
+    [XmlInclude(typeof(Battery))]
+    [XmlInclude(typeof(BatteryThresholdLow))]
+    [XmlInclude(typeof(BatteryThresholdHigh))]
+    [XmlInclude(typeof(BatteryCalibration0))]
+    [XmlInclude(typeof(BatteryCalibration1))]
+    [XmlInclude(typeof(TimestampedConfig))]
+    [XmlInclude(typeof(TimestampedDevicesConnected))]
+    [XmlInclude(typeof(TimestampedRepeaterStatus))]
+    [XmlInclude(typeof(TimestampedBatteryRate))]
+    [XmlInclude(typeof(TimestampedBattery))]
+    [XmlInclude(typeof(TimestampedBatteryThresholdLow))]
+    [XmlInclude(typeof(TimestampedBatteryThresholdHigh))]
+    [XmlInclude(typeof(TimestampedBatteryCalibration0))]
+    [XmlInclude(typeof(TimestampedBatteryCalibration1))]
+    [Description("Filters and selects specific messages reported by the TimestampGeneratorGen3 device.")]
+    public partial class Parse : ParseBuilder, INamedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Parse"/> class.
+        /// </summary>
+        public Parse()
+        {
+            Register = new Config();
+        }
+
+        string INamedElement.Name => $"{nameof(TimestampGeneratorGen3)}.{GetElementDisplayName(Register)}";
+    }
+
+    /// <summary>
+    /// Represents an operator which formats a sequence of values as specific
+    /// TimestampGeneratorGen3 register messages.
+    /// </summary>
+    /// <seealso cref="Config"/>
+    /// <seealso cref="DevicesConnected"/>
+    /// <seealso cref="RepeaterStatus"/>
+    /// <seealso cref="BatteryRate"/>
+    /// <seealso cref="Battery"/>
+    /// <seealso cref="BatteryThresholdLow"/>
+    /// <seealso cref="BatteryThresholdHigh"/>
+    /// <seealso cref="BatteryCalibration0"/>
+    /// <seealso cref="BatteryCalibration1"/>
+    [XmlInclude(typeof(Config))]
+    [XmlInclude(typeof(DevicesConnected))]
+    [XmlInclude(typeof(RepeaterStatus))]
+    [XmlInclude(typeof(BatteryRate))]
+    [XmlInclude(typeof(Battery))]
+    [XmlInclude(typeof(BatteryThresholdLow))]
+    [XmlInclude(typeof(BatteryThresholdHigh))]
+    [XmlInclude(typeof(BatteryCalibration0))]
+    [XmlInclude(typeof(BatteryCalibration1))]
+    [Description("Formats a sequence of values as specific TimestampGeneratorGen3 register messages.")]
+    public partial class Format : FormatBuilder, INamedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Format"/> class.
+        /// </summary>
+        public Format()
+        {
+            Register = new Config();
+        }
+
+        string INamedElement.Name => $"{nameof(TimestampGeneratorGen3)}.{GetElementDisplayName(Register)}";
+    }
+
+    /// <summary>
+    /// Represents a register that specifies the device configuration.
+    /// </summary>
+    [Description("Specifies the device configuration")]
+    public partial class Config
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Config"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 32;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Config"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Config"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Config"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Config"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Config"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Config"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Config"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Config"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// Config register.
+    /// </summary>
+    /// <seealso cref="Config"/>
+    [Description("Filters and selects timestamped messages from the Config register.")]
+    public partial class TimestampedConfig
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Config"/> register. This field is constant.
+        /// </summary>
+        public const int Address = Config.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Config"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
+        {
+            return Config.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that reads whether the port has a device connected to (bitmask).
+    /// </summary>
+    [Description("Reads whether the port has a device connected to (bitmask)")]
+    public partial class DevicesConnected
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="DevicesConnected"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 33;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="DevicesConnected"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="DevicesConnected"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="DevicesConnected"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="DevicesConnected"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="DevicesConnected"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="DevicesConnected"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="DevicesConnected"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="DevicesConnected"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// DevicesConnected register.
+    /// </summary>
+    /// <seealso cref="DevicesConnected"/>
+    [Description("Filters and selects timestamped messages from the DevicesConnected register.")]
+    public partial class TimestampedDevicesConnected
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="DevicesConnected"/> register. This field is constant.
+        /// </summary>
+        public const int Address = DevicesConnected.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="DevicesConnected"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
+        {
+            return DevicesConnected.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that check whether device is a repeater or spreading internal timestamp.
+    /// </summary>
+    [Description("Check whether device is a repeater or spreading internal timestamp")]
+    public partial class RepeaterStatus
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="RepeaterStatus"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 34;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="RepeaterStatus"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="RepeaterStatus"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="RepeaterStatus"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="RepeaterStatus"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="RepeaterStatus"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="RepeaterStatus"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="RepeaterStatus"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="RepeaterStatus"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// RepeaterStatus register.
+    /// </summary>
+    /// <seealso cref="RepeaterStatus"/>
+    [Description("Filters and selects timestamped messages from the RepeaterStatus register.")]
+    public partial class TimestampedRepeaterStatus
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="RepeaterStatus"/> register. This field is constant.
+        /// </summary>
+        public const int Address = RepeaterStatus.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="RepeaterStatus"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
+        {
+            return RepeaterStatus.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that configure how often the battery calue is sent to computer.
+    /// </summary>
+    [Description("Configure how often the battery calue is sent to computer")]
+    public partial class BatteryRate
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryRate"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 35;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="BatteryRate"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U8;
+
+        /// <summary>
+        /// Represents the length of the <see cref="BatteryRate"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="BatteryRate"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static byte GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="BatteryRate"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadByte();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="BatteryRate"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryRate"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="BatteryRate"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryRate"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        {
+            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// BatteryRate register.
+    /// </summary>
+    /// <seealso cref="BatteryRate"/>
+    [Description("Filters and selects timestamped messages from the BatteryRate register.")]
+    public partial class TimestampedBatteryRate
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryRate"/> register. This field is constant.
+        /// </summary>
+        public const int Address = BatteryRate.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="BatteryRate"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<byte> GetPayload(HarpMessage message)
+        {
+            return BatteryRate.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that reads the current battery charge.
+    /// </summary>
+    [Description("Reads the current battery charge")]
+    public partial class Battery
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Battery"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 36;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="Battery"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.Float;
+
+        /// <summary>
+        /// Represents the length of the <see cref="Battery"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="Battery"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static float GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadSingle();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="Battery"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<float> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadSingle();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="Battery"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Battery"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, float value)
+        {
+            return HarpMessage.FromSingle(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="Battery"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="Battery"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, float value)
+        {
+            return HarpMessage.FromSingle(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// Battery register.
+    /// </summary>
+    /// <seealso cref="Battery"/>
+    [Description("Filters and selects timestamped messages from the Battery register.")]
+    public partial class TimestampedBattery
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="Battery"/> register. This field is constant.
+        /// </summary>
+        public const int Address = Battery.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="Battery"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<float> GetPayload(HarpMessage message)
+        {
+            return Battery.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that specifies the low threshold from where the battery should start to be charged.
+    /// </summary>
+    [Description("Specifies the low threshold from where the battery should start to be charged")]
+    public partial class BatteryThresholdLow
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryThresholdLow"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 37;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="BatteryThresholdLow"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.Float;
+
+        /// <summary>
+        /// Represents the length of the <see cref="BatteryThresholdLow"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="BatteryThresholdLow"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static float GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadSingle();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="BatteryThresholdLow"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<float> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadSingle();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="BatteryThresholdLow"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryThresholdLow"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, float value)
+        {
+            return HarpMessage.FromSingle(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="BatteryThresholdLow"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryThresholdLow"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, float value)
+        {
+            return HarpMessage.FromSingle(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// BatteryThresholdLow register.
+    /// </summary>
+    /// <seealso cref="BatteryThresholdLow"/>
+    [Description("Filters and selects timestamped messages from the BatteryThresholdLow register.")]
+    public partial class TimestampedBatteryThresholdLow
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryThresholdLow"/> register. This field is constant.
+        /// </summary>
+        public const int Address = BatteryThresholdLow.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="BatteryThresholdLow"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<float> GetPayload(HarpMessage message)
+        {
+            return BatteryThresholdLow.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that specifies the high threshold from where the battery stops being charged.
+    /// </summary>
+    [Description("Specifies the high threshold from where the battery stops being charged")]
+    public partial class BatteryThresholdHigh
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryThresholdHigh"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 38;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="BatteryThresholdHigh"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.Float;
+
+        /// <summary>
+        /// Represents the length of the <see cref="BatteryThresholdHigh"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="BatteryThresholdHigh"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static float GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadSingle();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="BatteryThresholdHigh"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<float> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadSingle();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="BatteryThresholdHigh"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryThresholdHigh"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, float value)
+        {
+            return HarpMessage.FromSingle(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="BatteryThresholdHigh"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryThresholdHigh"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, float value)
+        {
+            return HarpMessage.FromSingle(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// BatteryThresholdHigh register.
+    /// </summary>
+    /// <seealso cref="BatteryThresholdHigh"/>
+    [Description("Filters and selects timestamped messages from the BatteryThresholdHigh register.")]
+    public partial class TimestampedBatteryThresholdHigh
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryThresholdHigh"/> register. This field is constant.
+        /// </summary>
+        public const int Address = BatteryThresholdHigh.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="BatteryThresholdHigh"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<float> GetPayload(HarpMessage message)
+        {
+            return BatteryThresholdHigh.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that manipulates messages from register BatteryCalibration0.
+    /// </summary>
+    [Description("")]
+    public partial class BatteryCalibration0
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryCalibration0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 39;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="BatteryCalibration0"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="BatteryCalibration0"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="BatteryCalibration0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="BatteryCalibration0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="BatteryCalibration0"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryCalibration0"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="BatteryCalibration0"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryCalibration0"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// BatteryCalibration0 register.
+    /// </summary>
+    /// <seealso cref="BatteryCalibration0"/>
+    [Description("Filters and selects timestamped messages from the BatteryCalibration0 register.")]
+    public partial class TimestampedBatteryCalibration0
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryCalibration0"/> register. This field is constant.
+        /// </summary>
+        public const int Address = BatteryCalibration0.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="BatteryCalibration0"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
+        {
+            return BatteryCalibration0.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents a register that manipulates messages from register BatteryCalibration1.
+    /// </summary>
+    [Description("")]
+    public partial class BatteryCalibration1
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryCalibration1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = 40;
+
+        /// <summary>
+        /// Represents the payload type of the <see cref="BatteryCalibration1"/> register. This field is constant.
+        /// </summary>
+        public const PayloadType RegisterType = PayloadType.U16;
+
+        /// <summary>
+        /// Represents the length of the <see cref="BatteryCalibration1"/> register. This field is constant.
+        /// </summary>
+        public const int RegisterLength = 1;
+
+        /// <summary>
+        /// Returns the payload data for <see cref="BatteryCalibration1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the message payload.</returns>
+        public static ushort GetPayload(HarpMessage message)
+        {
+            return message.GetPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns the timestamped payload data for <see cref="BatteryCalibration1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetTimestampedPayload(HarpMessage message)
+        {
+            return message.GetTimestampedPayloadUInt16();
+        }
+
+        /// <summary>
+        /// Returns a Harp message for the <see cref="BatteryCalibration1"/> register.
+        /// </summary>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryCalibration1"/> register
+        /// with the specified message type and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, messageType, value);
+        }
+
+        /// <summary>
+        /// Returns a timestamped Harp message for the <see cref="BatteryCalibration1"/>
+        /// register.
+        /// </summary>
+        /// <param name="timestamp">The timestamp of the message payload, in seconds.</param>
+        /// <param name="messageType">The type of the Harp message.</param>
+        /// <param name="value">The value to be stored in the message payload.</param>
+        /// <returns>
+        /// A <see cref="HarpMessage"/> object for the <see cref="BatteryCalibration1"/> register
+        /// with the specified message type, timestamp, and payload.
+        /// </returns>
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ushort value)
+        {
+            return HarpMessage.FromUInt16(Address, timestamp, messageType, value);
+        }
+    }
+
+    /// <summary>
+    /// Provides methods for manipulating timestamped messages from the
+    /// BatteryCalibration1 register.
+    /// </summary>
+    /// <seealso cref="BatteryCalibration1"/>
+    [Description("Filters and selects timestamped messages from the BatteryCalibration1 register.")]
+    public partial class TimestampedBatteryCalibration1
+    {
+        /// <summary>
+        /// Represents the address of the <see cref="BatteryCalibration1"/> register. This field is constant.
+        /// </summary>
+        public const int Address = BatteryCalibration1.Address;
+
+        /// <summary>
+        /// Returns timestamped payload data for <see cref="BatteryCalibration1"/> register messages.
+        /// </summary>
+        /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
+        /// <returns>A value representing the timestamped message payload.</returns>
+        public static Timestamped<ushort> GetPayload(HarpMessage message)
+        {
+            return BatteryCalibration1.GetTimestampedPayload(message);
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator which creates standard message payloads for the
+    /// TimestampGeneratorGen3 device.
+    /// </summary>
+    /// <seealso cref="CreateConfigPayload"/>
+    /// <seealso cref="CreateDevicesConnectedPayload"/>
+    /// <seealso cref="CreateRepeaterStatusPayload"/>
+    /// <seealso cref="CreateBatteryRatePayload"/>
+    /// <seealso cref="CreateBatteryPayload"/>
+    /// <seealso cref="CreateBatteryThresholdLowPayload"/>
+    /// <seealso cref="CreateBatteryThresholdHighPayload"/>
+    /// <seealso cref="CreateBatteryCalibration0Payload"/>
+    /// <seealso cref="CreateBatteryCalibration1Payload"/>
+    [XmlInclude(typeof(CreateConfigPayload))]
+    [XmlInclude(typeof(CreateDevicesConnectedPayload))]
+    [XmlInclude(typeof(CreateRepeaterStatusPayload))]
+    [XmlInclude(typeof(CreateBatteryRatePayload))]
+    [XmlInclude(typeof(CreateBatteryPayload))]
+    [XmlInclude(typeof(CreateBatteryThresholdLowPayload))]
+    [XmlInclude(typeof(CreateBatteryThresholdHighPayload))]
+    [XmlInclude(typeof(CreateBatteryCalibration0Payload))]
+    [XmlInclude(typeof(CreateBatteryCalibration1Payload))]
+    [Description("Creates standard message payloads for the TimestampGeneratorGen3 device.")]
+    public partial class CreateMessage : CreateMessageBuilder, INamedElement
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateMessage"/> class.
+        /// </summary>
+        public CreateMessage()
+        {
+            Payload = new CreateConfigPayload();
+        }
+
+        string INamedElement.Name => $"{nameof(TimestampGeneratorGen3)}.{GetElementDisplayName(Payload)}";
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the device configuration.
+    /// </summary>
+    [DisplayName("ConfigPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the device configuration.")]
+    public partial class CreateConfigPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the device configuration.
+        /// </summary>
+        [Description("The value that specifies the device configuration.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the device configuration.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the device configuration.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Config.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that reads whether the port has a device connected to (bitmask).
+    /// </summary>
+    [DisplayName("DevicesConnectedPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that reads whether the port has a device connected to (bitmask).")]
+    public partial class CreateDevicesConnectedPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that reads whether the port has a device connected to (bitmask).
+        /// </summary>
+        [Description("The value that reads whether the port has a device connected to (bitmask).")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that reads whether the port has a device connected to (bitmask).
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that reads whether the port has a device connected to (bitmask).
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => DevicesConnected.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that check whether device is a repeater or spreading internal timestamp.
+    /// </summary>
+    [DisplayName("RepeaterStatusPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that check whether device is a repeater or spreading internal timestamp.")]
+    public partial class CreateRepeaterStatusPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that check whether device is a repeater or spreading internal timestamp.
+        /// </summary>
+        [Description("The value that check whether device is a repeater or spreading internal timestamp.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that check whether device is a repeater or spreading internal timestamp.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that check whether device is a repeater or spreading internal timestamp.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => RepeaterStatus.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that configure how often the battery calue is sent to computer.
+    /// </summary>
+    [DisplayName("BatteryRatePayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that configure how often the battery calue is sent to computer.")]
+    public partial class CreateBatteryRatePayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that configure how often the battery calue is sent to computer.
+        /// </summary>
+        [Description("The value that configure how often the battery calue is sent to computer.")]
+        public byte Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that configure how often the battery calue is sent to computer.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that configure how often the battery calue is sent to computer.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => BatteryRate.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that reads the current battery charge.
+    /// </summary>
+    [DisplayName("BatteryPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that reads the current battery charge.")]
+    public partial class CreateBatteryPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that reads the current battery charge.
+        /// </summary>
+        [Description("The value that reads the current battery charge.")]
+        public float Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that reads the current battery charge.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that reads the current battery charge.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => Battery.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the low threshold from where the battery should start to be charged.
+    /// </summary>
+    [DisplayName("BatteryThresholdLowPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the low threshold from where the battery should start to be charged.")]
+    public partial class CreateBatteryThresholdLowPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the low threshold from where the battery should start to be charged.
+        /// </summary>
+        [Description("The value that specifies the low threshold from where the battery should start to be charged.")]
+        public float Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the low threshold from where the battery should start to be charged.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the low threshold from where the battery should start to be charged.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => BatteryThresholdLow.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// that specifies the high threshold from where the battery stops being charged.
+    /// </summary>
+    [DisplayName("BatteryThresholdHighPayload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads that specifies the high threshold from where the battery stops being charged.")]
+    public partial class CreateBatteryThresholdHighPayload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value that specifies the high threshold from where the battery stops being charged.
+        /// </summary>
+        [Description("The value that specifies the high threshold from where the battery stops being charged.")]
+        public float Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// that specifies the high threshold from where the battery stops being charged.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// that specifies the high threshold from where the battery stops being charged.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => BatteryThresholdHigh.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// for register BatteryCalibration0.
+    /// </summary>
+    [DisplayName("BatteryCalibration0Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads for register BatteryCalibration0.")]
+    public partial class CreateBatteryCalibration0Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value for register BatteryCalibration0.
+        /// </summary>
+        [Description("The value for register BatteryCalibration0.")]
+        public ushort Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// for register BatteryCalibration0.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// for register BatteryCalibration0.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => BatteryCalibration0.FromPayload(MessageType, Value));
+        }
+    }
+
+    /// <summary>
+    /// Represents an operator that creates a sequence of message payloads
+    /// for register BatteryCalibration1.
+    /// </summary>
+    [DisplayName("BatteryCalibration1Payload")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Creates a sequence of message payloads for register BatteryCalibration1.")]
+    public partial class CreateBatteryCalibration1Payload : HarpCombinator
+    {
+        /// <summary>
+        /// Gets or sets the value for register BatteryCalibration1.
+        /// </summary>
+        [Description("The value for register BatteryCalibration1.")]
+        public ushort Value { get; set; }
+
+        /// <summary>
+        /// Creates an observable sequence that contains a single message
+        /// for register BatteryCalibration1.
+        /// </summary>
+        /// <returns>
+        /// A sequence containing a single <see cref="HarpMessage"/> object
+        /// representing the created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process()
+        {
+            return Process(Observable.Return(System.Reactive.Unit.Default));
+        }
+
+        /// <summary>
+        /// Creates an observable sequence of message payloads
+        /// for register BatteryCalibration1.
+        /// </summary>
+        /// <typeparam name="TSource">
+        /// The type of the elements in the <paramref name="source"/> sequence.
+        /// </typeparam>
+        /// <param name="source">
+        /// The sequence containing the notifications used for emitting message payloads.
+        /// </param>
+        /// <returns>
+        /// A sequence of <see cref="HarpMessage"/> objects representing each
+        /// created message payload.
+        /// </returns>
+        public IObservable<HarpMessage> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(_ => BatteryCalibration1.FromPayload(MessageType, Value));
+        }
+    }
+}

--- a/Interface/Harp.TimestampGeneratorGen3/Device.Generated.cs
+++ b/Interface/Harp.TimestampGeneratorGen3/Device.Generated.cs
@@ -216,9 +216,9 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the message payload.</returns>
-        public static byte GetPayload(HarpMessage message)
+        public static ConfigurationFlags GetPayload(HarpMessage message)
         {
-            return message.GetPayloadByte();
+            return (ConfigurationFlags)message.GetPayloadByte();
         }
 
         /// <summary>
@@ -226,9 +226,10 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        public static Timestamped<ConfigurationFlags> GetTimestampedPayload(HarpMessage message)
         {
-            return message.GetTimestampedPayloadByte();
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((ConfigurationFlags)payload.Value, payload.Seconds);
         }
 
         /// <summary>
@@ -240,9 +241,9 @@ namespace Harp.TimestampGeneratorGen3
         /// A <see cref="HarpMessage"/> object for the <see cref="Config"/> register
         /// with the specified message type and payload.
         /// </returns>
-        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        public static HarpMessage FromPayload(MessageType messageType, ConfigurationFlags value)
         {
-            return HarpMessage.FromByte(Address, messageType, value);
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
         }
 
         /// <summary>
@@ -256,9 +257,9 @@ namespace Harp.TimestampGeneratorGen3
         /// A <see cref="HarpMessage"/> object for the <see cref="Config"/> register
         /// with the specified message type, timestamp, and payload.
         /// </returns>
-        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, ConfigurationFlags value)
         {
-            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
     }
 
@@ -280,7 +281,7 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<byte> GetPayload(HarpMessage message)
+        public static Timestamped<ConfigurationFlags> GetPayload(HarpMessage message)
         {
             return Config.GetTimestampedPayload(message);
         }
@@ -408,9 +409,9 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the message payload.</returns>
-        public static byte GetPayload(HarpMessage message)
+        public static RepeaterFlags GetPayload(HarpMessage message)
         {
-            return message.GetPayloadByte();
+            return (RepeaterFlags)message.GetPayloadByte();
         }
 
         /// <summary>
@@ -418,9 +419,10 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        public static Timestamped<RepeaterFlags> GetTimestampedPayload(HarpMessage message)
         {
-            return message.GetTimestampedPayloadByte();
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((RepeaterFlags)payload.Value, payload.Seconds);
         }
 
         /// <summary>
@@ -432,9 +434,9 @@ namespace Harp.TimestampGeneratorGen3
         /// A <see cref="HarpMessage"/> object for the <see cref="RepeaterStatus"/> register
         /// with the specified message type and payload.
         /// </returns>
-        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        public static HarpMessage FromPayload(MessageType messageType, RepeaterFlags value)
         {
-            return HarpMessage.FromByte(Address, messageType, value);
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
         }
 
         /// <summary>
@@ -448,9 +450,9 @@ namespace Harp.TimestampGeneratorGen3
         /// A <see cref="HarpMessage"/> object for the <see cref="RepeaterStatus"/> register
         /// with the specified message type, timestamp, and payload.
         /// </returns>
-        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, RepeaterFlags value)
         {
-            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
     }
 
@@ -472,7 +474,7 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<byte> GetPayload(HarpMessage message)
+        public static Timestamped<RepeaterFlags> GetPayload(HarpMessage message)
         {
             return RepeaterStatus.GetTimestampedPayload(message);
         }
@@ -504,9 +506,9 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the message payload.</returns>
-        public static byte GetPayload(HarpMessage message)
+        public static BatteryRateConfiguration GetPayload(HarpMessage message)
         {
-            return message.GetPayloadByte();
+            return (BatteryRateConfiguration)message.GetPayloadByte();
         }
 
         /// <summary>
@@ -514,9 +516,10 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<byte> GetTimestampedPayload(HarpMessage message)
+        public static Timestamped<BatteryRateConfiguration> GetTimestampedPayload(HarpMessage message)
         {
-            return message.GetTimestampedPayloadByte();
+            var payload = message.GetTimestampedPayloadByte();
+            return Timestamped.Create((BatteryRateConfiguration)payload.Value, payload.Seconds);
         }
 
         /// <summary>
@@ -528,9 +531,9 @@ namespace Harp.TimestampGeneratorGen3
         /// A <see cref="HarpMessage"/> object for the <see cref="BatteryRate"/> register
         /// with the specified message type and payload.
         /// </returns>
-        public static HarpMessage FromPayload(MessageType messageType, byte value)
+        public static HarpMessage FromPayload(MessageType messageType, BatteryRateConfiguration value)
         {
-            return HarpMessage.FromByte(Address, messageType, value);
+            return HarpMessage.FromByte(Address, messageType, (byte)value);
         }
 
         /// <summary>
@@ -544,9 +547,9 @@ namespace Harp.TimestampGeneratorGen3
         /// A <see cref="HarpMessage"/> object for the <see cref="BatteryRate"/> register
         /// with the specified message type, timestamp, and payload.
         /// </returns>
-        public static HarpMessage FromPayload(double timestamp, MessageType messageType, byte value)
+        public static HarpMessage FromPayload(double timestamp, MessageType messageType, BatteryRateConfiguration value)
         {
-            return HarpMessage.FromByte(Address, timestamp, messageType, value);
+            return HarpMessage.FromByte(Address, timestamp, messageType, (byte)value);
         }
     }
 
@@ -568,7 +571,7 @@ namespace Harp.TimestampGeneratorGen3
         /// </summary>
         /// <param name="message">A <see cref="HarpMessage"/> object representing the register message.</param>
         /// <returns>A value representing the timestamped message payload.</returns>
-        public static Timestamped<byte> GetPayload(HarpMessage message)
+        public static Timestamped<BatteryRateConfiguration> GetPayload(HarpMessage message)
         {
             return BatteryRate.GetTimestampedPayload(message);
         }
@@ -1103,7 +1106,7 @@ namespace Harp.TimestampGeneratorGen3
         /// Gets or sets the value that specifies the device configuration.
         /// </summary>
         [Description("The value that specifies the device configuration.")]
-        public byte Value { get; set; }
+        public ConfigurationFlags Value { get; set; }
 
         /// <summary>
         /// Creates an observable sequence that contains a single message
@@ -1199,7 +1202,7 @@ namespace Harp.TimestampGeneratorGen3
         /// Gets or sets the value that check whether device is a repeater or spreading internal timestamp.
         /// </summary>
         [Description("The value that check whether device is a repeater or spreading internal timestamp.")]
-        public byte Value { get; set; }
+        public RepeaterFlags Value { get; set; }
 
         /// <summary>
         /// Creates an observable sequence that contains a single message
@@ -1247,7 +1250,7 @@ namespace Harp.TimestampGeneratorGen3
         /// Gets or sets the value that configure how often the battery calue is sent to computer.
         /// </summary>
         [Description("The value that configure how often the battery calue is sent to computer.")]
-        public byte Value { get; set; }
+        public BatteryRateConfiguration Value { get; set; }
 
         /// <summary>
         /// Creates an observable sequence that contains a single message
@@ -1520,5 +1523,70 @@ namespace Harp.TimestampGeneratorGen3
         {
             return source.Select(_ => BatteryCalibration1.FromPayload(MessageType, Value));
         }
+    }
+
+    /// <summary>
+    /// Specifies configuration flags for the device.
+    /// </summary>
+    [Flags]
+    public enum ConfigurationFlags : byte
+    {
+        /// <summary>
+        /// Starts battery cycle to extend batteries life.
+        /// </summary>
+        StartBatteryCycle = 0x1,
+
+        /// <summary>
+        /// Starts to discharge right away.
+        /// </summary>
+        StartDischarge = 0x2,
+
+        /// <summary>
+        /// Starts to charge right away.
+        /// </summary>
+        StartCharge = 0x4,
+
+        /// <summary>
+        /// Stop any control of the battery and resume normal function.
+        /// </summary>
+        Stop = 0x8
+    }
+
+    /// <summary>
+    /// Specifies whether the device is a clock repeater.
+    /// </summary>
+    [Flags]
+    public enum RepeaterFlags : byte
+    {
+        /// <summary>
+        /// The device is a repeater.
+        /// </summary>
+        Repeater = 0x1
+    }
+
+    /// <summary>
+    /// Specifies the rate at which the battery charge is sent.
+    /// </summary>
+    public enum BatteryRateConfiguration : byte
+    {
+        /// <summary>
+        /// The charge is sent every minute.
+        /// </summary>
+        EveryMinute = 0,
+
+        /// <summary>
+        /// The charge is sent every 10 seconds.
+        /// </summary>
+        Every10Seconds = 1,
+
+        /// <summary>
+        /// The charge is sent every second.
+        /// </summary>
+        EverySecond = 2,
+
+        /// <summary>
+        /// The battery charge is not sent.
+        /// </summary>
+        Never = 3
     }
 }

--- a/Interface/Harp.TimestampGeneratorGen3/Harp.TimestampGeneratorGen3.csproj
+++ b/Interface/Harp.TimestampGeneratorGen3/Harp.TimestampGeneratorGen3.csproj
@@ -4,6 +4,8 @@
     <Title>Harp.TimestampGeneratorGen3</Title>
     <Authors></Authors>
     <Copyright>Copyright © harp-tech 2023</Copyright>
+    <IncludeSymbols Condition="'$(Configuration)'=='Release'">true</IncludeSymbols>
+    <SymbolPackageFormat Condition="'$(Configuration)'=='Release'">snupkg</SymbolPackageFormat>
     <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
     <Description>Bonsai Library containing interfaces for data acquisition and control of Harp TimestampGenerator Gen3 devices.</Description>
     <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>

--- a/Interface/Harp.TimestampGeneratorGen3/Harp.TimestampGeneratorGen3.csproj
+++ b/Interface/Harp.TimestampGeneratorGen3/Harp.TimestampGeneratorGen3.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Harp.TimestampGeneratorGen3</Title>
+    <Authors></Authors>
+    <Copyright>Copyright © harp-tech 2023</Copyright>
+    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
+    <Description>Bonsai Library containing interfaces for data acquisition and control of Harp TimestampGenerator Gen3 devices.</Description>
+    <GenerateDocumentationFile Condition="'$(Configuration)'=='Release'">true</GenerateDocumentationFile>
+    <PackageTags>Harp TimestampGenerator Gen3 Bonsai Rx</PackageTags>
+    <PackageProjectUrl></PackageProjectUrl>
+    <PackageLicenseExpression></PackageLicenseExpression>
+    <PackageIcon></PackageIcon>
+    <PackageOutputPath></PackageOutputPath>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionSuffix>build032801</VersionSuffix>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bonsai.Harp" Version="3.5.0-build032701" GeneratePathProperty="true" />
+  </ItemGroup>
+
+</Project>

--- a/Interface/Harp.TimestampGeneratorGen3/Properties/AssemblyInfo.cs
+++ b/Interface/Harp.TimestampGeneratorGen3/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:Harp.TimestampGeneratorGen3", null)]
+[assembly: WorkflowNamespaceIcon("Bonsai:ElementIcon.Daq")]

--- a/Interface/Harp.TimestampGeneratorGen3/Properties/launchSettings.json
+++ b/Interface/Harp.TimestampGeneratorGen3/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Executable",
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Goncalo Lopes\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:$(TargetDir)."
+    }
+  }
+}

--- a/Interface/LICENSE
+++ b/Interface/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2023 harp-tech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/device.yml
+++ b/device.yml
@@ -10,6 +10,7 @@ registers:
     address: 32
     type: U8
     access: Write
+    maskType: ConfigurationFlags
     description: Specifies the device configuration
   DevicesConnected:
     address: 33
@@ -20,11 +21,13 @@ registers:
     address: 34
     type: U8
     access: Write
+    maskType: RepeaterFlags
     description: Check whether device is a repeater or spreading internal timestamp
   BatteryRate:
     address: 35
     type: U8
     access: Write
+    maskType: BatteryRateConfiguration
     description: Configure how often the battery calue is sent to computer
   Battery:
     address: 36
@@ -49,3 +52,23 @@ registers:
     address: 40
     type: U16
     access: Write
+bitMasks:
+  ConfigurationFlags:
+    description: Specifies configuration flags for the device.
+    bits:
+      StartBatteryCycle: {0x1, description: Starts battery cycle to extend batteries life.}
+      StartDischarge: {0x2, description: Starts to discharge right away.}
+      StartCharge: {0x4, description: Starts to charge right away.}
+      Stop: {0x8, description: Stop any control of the battery and resume normal function.}
+  RepeaterFlags:
+    description: Specifies whether the device is a clock repeater.
+    bits:
+      Repeater: {0x1, description: The device is a repeater.}
+groupMasks:
+  BatteryRateConfiguration:
+    description: Specifies the rate at which the battery charge is sent.
+    values:
+      EveryMinute: {0, description: The charge is sent every minute.}
+      Every10Seconds: {1, description: The charge is sent every 10 seconds.}
+      EverySecond: {2, description: The charge is sent every second.}
+      Never: {3, description: The battery charge is not sent.}

--- a/device.yml
+++ b/device.yml
@@ -1,0 +1,51 @@
+%YAML 1.1
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/harp-tech/reflex-generator/main/schema/device.json
+device: TimestampGeneratorGen3
+whoAmI: 1158
+firmwareVersion: "1.0"
+hardwareTargets: "1.2"
+registers:
+  Config:
+    address: 32
+    type: U8
+    access: Write
+    description: Specifies the device configuration
+  DevicesConnected:
+    address: 33
+    type: U8
+    access: Event
+    description: Reads whether the port has a device connected to (bitmask)
+  RepeaterStatus:
+    address: 34
+    type: U8
+    access: Write
+    description: Check whether device is a repeater or spreading internal timestamp
+  BatteryRate:
+    address: 35
+    type: U8
+    access: Write
+    description: Configure how often the battery calue is sent to computer
+  Battery:
+    address: 36
+    type: Float
+    access: Event
+    description: Reads the current battery charge
+  BatteryThresholdLow:
+    address: 37
+    type: Float
+    access: Write
+    description: Specifies the low threshold from where the battery should start to be charged
+  BatteryThresholdHigh:
+    address: 38
+    type: Float
+    access: Write
+    description: Specifies the high threshold from where the battery stops being charged
+  BatteryCalibration0:
+    address: 39
+    type: U16
+    access: Write
+  BatteryCalibration1:
+    address: 40
+    type: U16
+    access: Write


### PR DESCRIPTION
This PR adds the first draft of the TimestampGenerator Gen3 device metadata file, together with the corresponding auto-generated Bonsai high-level interface. The metadata YML file makes use of merge operators to avoid repeating declarations as much as possible, and currently relies on bitmask values to represent digital input and output port state.