### PR TITLE
Fix broken image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This device generates programable timestamps to up to 6 harp devices.
 
-![HarpTimestampGeneratorGen3](./Assets/pcb.jpg)
+![HarpTimestampGeneratorGen3](./Assets/pcb.png)
 
 ### Key Features ###
 


### PR DESCRIPTION
The link to the board picture had the wrong extension.